### PR TITLE
solve issue of low contrast

### DIFF
--- a/res/layout-sw350dp/activity_main.xml
+++ b/res/layout-sw350dp/activity_main.xml
@@ -370,7 +370,7 @@
             android:layout_below="@+id/NFCTagsSeparator"
             android:layout_centerHorizontal="true"
             android:layout_marginTop="15dp"
-            android:textColor="#696969"
+            android:textColor="#646464"
             android:visibility="invisible" />
 
     </RelativeLayout>

--- a/res/layout-sw480dp/activity_main.xml
+++ b/res/layout-sw480dp/activity_main.xml
@@ -369,6 +369,7 @@
             android:textAppearance="?android:attr/textAppearanceLarge"
             android:text="@string/no_nfc_tags"
             android:id="@+id/noTags"
+            android:textColor="#696969"
             android:layout_below="@+id/NFCTagsSeparator"
             android:layout_centerHorizontal="true"
             android:layout_marginTop="15dp"

--- a/res/layout-sw480dp/activity_main.xml
+++ b/res/layout-sw480dp/activity_main.xml
@@ -369,11 +369,10 @@
             android:textAppearance="?android:attr/textAppearanceLarge"
             android:text="@string/no_nfc_tags"
             android:id="@+id/noTags"
-            android:textColor="#696969"
             android:layout_below="@+id/NFCTagsSeparator"
             android:layout_centerHorizontal="true"
             android:layout_marginTop="15dp"
-            android:textColor="#696969"
+            android:textColor="#646464"
             android:visibility="invisible" />
 
     </RelativeLayout>

--- a/res/layout-sw600dp/activity_main.xml
+++ b/res/layout-sw600dp/activity_main.xml
@@ -369,11 +369,10 @@
             android:textAppearance="?android:attr/textAppearanceLarge"
             android:text="@string/no_nfc_tags"
             android:id="@+id/noTags"
-            android:textColor="#696969"
+            android:textColor="#646464"
             android:layout_below="@+id/NFCTagsSeparator"
             android:layout_centerHorizontal="true"
             android:layout_marginTop="15dp"
-            android:textColor="#696969"
             android:visibility="invisible" />
 
     </RelativeLayout>

--- a/res/layout-sw600dp/activity_main.xml
+++ b/res/layout-sw600dp/activity_main.xml
@@ -369,6 +369,7 @@
             android:textAppearance="?android:attr/textAppearanceLarge"
             android:text="@string/no_nfc_tags"
             android:id="@+id/noTags"
+            android:textColor="#696969"
             android:layout_below="@+id/NFCTagsSeparator"
             android:layout_centerHorizontal="true"
             android:layout_marginTop="15dp"

--- a/res/layout/activity_main.xml
+++ b/res/layout/activity_main.xml
@@ -367,6 +367,7 @@
             android:textAppearance="?android:attr/textAppearanceLarge"
             android:text="@string/no_nfc_tags"
             android:id="@+id/noTags"
+            android:textColor="#646464"
             android:layout_below="@+id/NFCTagsSeparator"
             android:layout_centerHorizontal="true"
             android:layout_marginTop="15dp"

--- a/res/layout/activity_main.xml
+++ b/res/layout/activity_main.xml
@@ -371,7 +371,6 @@
             android:layout_below="@+id/NFCTagsSeparator"
             android:layout_centerHorizontal="true"
             android:layout_marginTop="15dp"
-            android:textColor="#696969"
             android:visibility="invisible" />
 
     </RelativeLayout>


### PR DESCRIPTION
The original text color of the component is '#696969', and the contrast between the text color ('#696969') and the background color ('#E3E3E3') does not meet the standard of WCAG 2.1. In other words, this color cannot be easily seen by everyone. So, to solve this problem, our team designed a tool that can automatically detect and repair such problems. The test report and recommended replacement colors ('#646464') are as follows:
![image](https://user-images.githubusercontent.com/101503193/167412071-45368e3a-8464-4577-81ff-6bce263beebb.png)
The figure on the left is the original page, the figure on the right is the repaired page, and the figure below is the problem detection report.
If you think it is useful, please give me feedback. Your feedback is very important to me. We sincerely hope to receive your suggestions and opinions as an app developer.